### PR TITLE
Fix bug with alternative = less in wp.t1

### DIFF
--- a/R/webpower.R
+++ b/R/webpower.R
@@ -348,7 +348,7 @@ wp.t1 <- function(n = NULL, d = NULL, alpha = 0.05, power = NULL, type = c("two.
         }
         if (ttside == 1) {
             d <- uniroot(function(d) eval(p.body) - power, c(-10, 5), tol = tol, 
-                extendInt = "upX")$root
+                extendInt = "downX")$root
         }
         if (ttside == 3) {
             d <- uniroot(function(d) eval(p.body) - power, c(-5, 10), tol = tol, 


### PR DESCRIPTION
This PR contains the fix for Issue #11 which I opened a few minutes ago.